### PR TITLE
Expose NodeData enum

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,8 @@ pub use document::Document;
 pub use dom_tree::Node;
 #[doc(hidden)]
 pub use dom_tree::NodeId;
+#[doc(hidden)]
+pub use dom_tree::NodeData;
 pub use dom_tree::NodeRef;
 #[doc(hidden)]
 pub use dom_tree::SerializableNodeRef;


### PR DESCRIPTION
Imagine you would like to iterate through `Text` nodes. It may be helpful when you have non-structured text intermixed with markup nodes.

```html
<div class="cls">
  <strong>Title</strong>
  1 | 2 | 3
  Love you
  <span>18+</span>
  John Doe
</div>
```

```rust
node.select(".cls").nodes().iter().filter(|it| it.query(|n| match n.data {
    NodeData::Text{ .. } => true,
    _ => false,
})),
```

The other way around would look like this:

```rust
node
  .select(".cls")
  .nodes()
  .iter()
  .flat_map(|node| node.children())
  .filter(|node| node.is_text())
  .map(|node| node.text())
  .collect::<Vec<_>>();
```

But this approach won't work for HTML comments.