### PR TITLE
feat: allow keeping templates as they are

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/*.rs.bk
 Cargo.lock
 *.go
+/.idea

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@ mod selection;
 mod traversal;
 
 pub use document::Document;
+pub use document::ParseOptions;
 pub use dom_tree::Node;
 #[doc(hidden)]
 pub use dom_tree::NodeId;

--- a/tests/templates.rs
+++ b/tests/templates.rs
@@ -1,0 +1,45 @@
+use markup5ever::interface::TreeSink;
+use nipper::{Document, ParseOptions};
+
+#[test]
+fn test_templates() {
+    let mut doc = Document::parse(
+        ParseOptions {
+            keep_templates: true,
+        },
+        r#"
+<html>
+    <body>
+        <template>
+            <p>Hello world!</p>
+        </template>
+    </body>
+</html>
+"#,
+    );
+
+    let nodes = doc
+        .select("template")
+        .nodes()
+        .iter()
+        .map(|n| n.id)
+        .collect::<Vec<_>>();
+    for node in nodes {
+        let c = doc.get_template_contents(&node);
+        println!("Node: {c:?}");
+        let data = doc.get_node(&node);
+        println!("Data: {data:?}");
+    }
+
+    let result = doc.html().to_string();
+    assert_eq!(
+        result,
+        r#"<html><head></head><body>
+        <template>
+            <p>Hello world!</p>
+        </template>
+    
+
+</body></html>"#
+    );
+}


### PR DESCRIPTION
In some cases the <template> tags should not be replaced, but kept as they are. This allows

Closes: trunk-rs/trunk#742